### PR TITLE
Fix disko ESP size format

### DIFF
--- a/hosts/blazar/modules/disko.nix
+++ b/hosts/blazar/modules/disko.nix
@@ -9,8 +9,8 @@ _: {
         type = "gpt";
         partitions = {
           ESP = {
-            start = "1MiB";
-            size = "512MiB";
+            start = "1M";
+            size = "512M";
             type = "EF00";
             content = {
               type = "filesystem";


### PR DESCRIPTION
## Summary
- adjust the ESP partition configuration to use sgdisk-compatible size units

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6076e9e34832bb624b4d05a9dab1e