### PR TITLE
ci: harden nixos build workflow

### DIFF
--- a/.github/workflows/nixos-build.yml
+++ b/.github/workflows/nixos-build.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /nix/store
             ~/.cache/nix
           key: nix-discovery-v2-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('flake.nix', 'hosts/**/*.nix') }}
           restore-keys: |
@@ -61,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: ${{ fromJSON(needs.discover.outputs.hosts) }}
+        host: ${{ fromJSON(needs.discover.outputs.hosts || '[]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -79,7 +78,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /nix/store
             ~/.cache/nix
           key: nix-build-v2-${{ matrix.host }}-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('hosts/${{ matrix.host }}/**/*.nix', 'nix/**/*.nix') }}
           restore-keys: |


### PR DESCRIPTION
## Context
- Resolve GitHub Actions failures caused by an empty build matrix and cache restoration errors in `nixos-build.yml`.

## Plan & changes
- Remove `/nix/store` from cache paths so the cache action no longer attempts to archive root-owned files.
- Default the build matrix to an empty array when discovery outputs are unavailable to avoid `fromJSON` parsing failures.

## Test evidence
- `nix develop -c treefmt` *(fails: `nix` not available in CI runner for validation)*

## Risk & rollback
- Low risk: workflow-only change. Revert `.github/workflows/nixos-build.yml` if new CI issues appear.

## MCP usage
- None.


------
https://chatgpt.com/codex/tasks/task_e_68da02f48014832b9508adbdeb2986fb